### PR TITLE
핫픽스 / 이메일 인증 관련

### DIFF
--- a/server/src/main/java/pkw/projectw/controller/UserController.java
+++ b/server/src/main/java/pkw/projectw/controller/UserController.java
@@ -1,11 +1,14 @@
 package pkw.projectw.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 import pkw.projectw.domain.User;
+import pkw.projectw.domain.UserRole;
 import pkw.projectw.service.CookieUtil;
 import pkw.projectw.service.JwtTokenUtil;
 import pkw.projectw.service.UserService;
@@ -39,6 +42,13 @@ public class UserController {
                                      HttpServletResponse response) {
         Map<String, String> auth = new HashMap<>();
         User user = userService.login(form.getEmail(), form.getPassword());
+
+        if (user.getRole().equals(UserRole.ROLE_NOT_PERMITTED)) {
+            response.setStatus(403);
+            verificationTokenService.createVerification(user.getEmail());
+            auth.put("authError", "이메일 인증이 필요합니다.");
+            return auth;
+        }
 
         final String accessToken = jwtTokenUtil.generateToken(user);
         final String refreshToken = jwtTokenUtil.generateRefreshToken(user);

--- a/server/src/main/java/pkw/projectw/domain/VerificationToken.java
+++ b/server/src/main/java/pkw/projectw/domain/VerificationToken.java
@@ -23,9 +23,9 @@ public class VerificationToken {
             generator = "VERIFICATION_SEQ_GEN"
     )
     private Long id;
-    private String token = UUID.randomUUID().toString();
+    private String token;
     private String status = STATUS_PENDING;
-    private LocalDateTime expireDateTime = LocalDateTime.now().plusDays(1);
+    private LocalDateTime expireDateTime;
 
     @OneToOne
     @JoinColumn(name = "USER_ID")

--- a/server/src/main/java/pkw/projectw/service/UserService.java
+++ b/server/src/main/java/pkw/projectw/service/UserService.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 import pkw.projectw.domain.User;
-import pkw.projectw.domain.UserRole;
 import pkw.projectw.repository.UserRepository;
 
 import java.util.Optional;
@@ -49,15 +48,7 @@ public class UserService {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "사용자 정보가 일치하지 않습니다.");
         }
 
-        if (isVerifiedUser(user)) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "인증되지 않은 사용자입니다.");
-        }
-
         return user;
-    }
-
-    private boolean isVerifiedUser(User user) {
-        return user.getRole().equals(UserRole.ROLE_NOT_PERMITTED);
     }
 
     public Optional<User> findOne(Long userId) {

--- a/server/src/main/java/pkw/projectw/service/VerificationTokenService.java
+++ b/server/src/main/java/pkw/projectw/service/VerificationTokenService.java
@@ -3,6 +3,7 @@ package pkw.projectw.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import pkw.projectw.domain.User;
 import pkw.projectw.domain.UserRole;
 import pkw.projectw.domain.VerificationToken;
@@ -10,8 +11,10 @@ import pkw.projectw.repository.UserRepository;
 import pkw.projectw.repository.VerificationTokenRepository;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class VerificationTokenService {
 
@@ -27,6 +30,9 @@ public class VerificationTokenService {
 
         VerificationToken verificationTokens = verificationTokenRepository
                 .findByUserEmail(email).orElseGet(VerificationToken::new);
+
+        verificationTokens.setToken(UUID.randomUUID().toString());
+        verificationTokens.setExpireDateTime(LocalDateTime.now().plusSeconds(20));
 
         if (verificationTokens.getUser() == null) {
             verificationTokens.setUser(user);


### PR DESCRIPTION
인증되지 않은 사용자가 로그인 시도 시 이메일 토큰을 다시 발급하여
인증 이메일 전송하도록 수정

관련: #1