### PR TITLE
Feature/start timer server

### DIFF
--- a/client/src/containers/chat/RoomContainer.jsx
+++ b/client/src/containers/chat/RoomContainer.jsx
@@ -90,7 +90,11 @@ const RoomContainer = ({ match, history }) => {
     });
 
   useEffect(() => {
-    const sub = stompSubscribe();
+    let sub;
+    if (!stompClient.connected) {
+      sub = stompClient.connect({}, stompSubscribe);
+    }
+    sub = stompSubscribe();
     dispatch(loadRoom({ roomId }));
     stompClient.send(
       '/pub/socket/message',

--- a/server/src/main/java/projectw/baesinzer/controller/MessageController.java
+++ b/server/src/main/java/projectw/baesinzer/controller/MessageController.java
@@ -2,17 +2,21 @@ package projectw.baesinzer.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
+import org.springframework.http.HttpStatus;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 import projectw.baesinzer.domain.Message;
 import projectw.baesinzer.domain.Room;
 import projectw.baesinzer.domain.UserInfo;
 import projectw.baesinzer.service.RoomService;
 
+import javax.servlet.http.HttpServletResponse;
 import java.util.Timer;
 import java.util.TimerTask;
 
@@ -34,6 +38,10 @@ public class MessageController {
 
                 // 최대 6명 까지 할당 번호 검사하여 없으면 할당
                 for (int i = 1; i <= 6; i++) {
+                    if (room.getCount() == 0) { // 방이 처음 만들어졌을 시 방장 설정
+                        userInfo.setHost(true);
+                    }
+
                     if (room.getUsers().get(i) == null) {
                         room.getUsers().put(i, userInfo);
                         userInfo.setUserNo(i);
@@ -53,6 +61,7 @@ public class MessageController {
                 Timer timer = new Timer();
                 TimerTask timerTask = new TimerTask() {
                     int count = 4;
+
                     @Override
                     public void run() {
                         if (count > 0) {
@@ -60,6 +69,9 @@ public class MessageController {
                             operations.convertAndSend("/sub/socket/room/" + room.getRoomCode(), message);
                             count--;
                         } else {
+                            room.setStart(true);
+                            message.setMessage("게임이 시작되었습니다.");
+                            operations.convertAndSend("/sub/socket/room/" + room.getRoomCode(), message);
                             timer.cancel();
                         }
                     }
@@ -86,6 +98,20 @@ public class MessageController {
                 if (room.getUsers().size() == 0) {
                     roomService.removeRoom(room);
                     break;
+                }
+
+                for (int i = 1; i <= 6; i++) {
+                    UserInfo nextHost = room.getUsers().get(i);
+                    System.out.println(nextHost);
+                    if (nextHost != null) {
+                        nextHost.setHost(true);
+                        Message nextHostMessage = new Message();
+                        nextHostMessage.setType(Message.MessageType.ROOM);
+                        nextHostMessage.setUserInfo(nextHost);
+                        nextHostMessage.setMessage(nextHost.getUsername() + " 님이 방장이 되셨습니다.");
+                        operations.convertAndSend("/sub/socket/room/" + room.getRoomCode(), nextHostMessage);
+                        break;
+                    }
                 }
 
                 headerAccessor.getSessionAttributes().remove("user");

--- a/server/src/main/java/projectw/baesinzer/controller/MessageController.java
+++ b/server/src/main/java/projectw/baesinzer/controller/MessageController.java
@@ -13,6 +13,9 @@ import projectw.baesinzer.domain.Room;
 import projectw.baesinzer.domain.UserInfo;
 import projectw.baesinzer.service.RoomService;
 
+import java.util.Timer;
+import java.util.TimerTask;
+
 @Controller
 @RequiredArgsConstructor
 public class MessageController {
@@ -41,6 +44,27 @@ public class MessageController {
                         break;
                     }
                 }
+                break;
+            case START:
+                UserInfo sys = new UserInfo();
+                sys.setUsername("System");
+                message.setUserInfo(sys);
+                message.setMessage("5초 뒤 게임이 시작됩니다.");
+                Timer timer = new Timer();
+                TimerTask timerTask = new TimerTask() {
+                    int count = 4;
+                    @Override
+                    public void run() {
+                        if (count > 0) {
+                            message.setMessage(count + "초 뒤 게임이 시작됩니다.");
+                            operations.convertAndSend("/sub/socket/room/" + room.getRoomCode(), message);
+                            count--;
+                        } else {
+                            timer.cancel();
+                        }
+                    }
+                };
+                timer.schedule(timerTask, 1000, 1000);
                 break;
             case VOTE_START:
                 for (int i = 1; i <= room.getCount(); i++) {

--- a/server/src/main/java/projectw/baesinzer/controller/RoomController.java
+++ b/server/src/main/java/projectw/baesinzer/controller/RoomController.java
@@ -25,9 +25,9 @@ public class RoomController {
     @GetMapping("/room/{roomCode}")
     public Room joinRoom(@PathVariable String roomCode) {
         Room room = roomService.findOne(roomCode);
-        if (room.getUsers().size() == 6) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 가득 찬 방입니다.");
-        }
+//        if (room.getUsers().size() == 6) {
+//            throw new ResponseStatusException(HttpStatus.CONFLICT, "이미 가득 찬 방입니다.");
+//        }
 
         return room;
     }

--- a/server/src/main/java/projectw/baesinzer/domain/Room.java
+++ b/server/src/main/java/projectw/baesinzer/domain/Room.java
@@ -18,4 +18,5 @@ public class Room {
     private String roomName;
     private int count;
     private Map<Integer, UserInfo> users;
+    private boolean start;
 }

--- a/server/src/main/java/projectw/baesinzer/domain/UserInfo.java
+++ b/server/src/main/java/projectw/baesinzer/domain/UserInfo.java
@@ -17,4 +17,5 @@ public class UserInfo {
     private int hasVoted;
     private int votedNum;
     private List<Mission> missionList;
+    private boolean host;
 }


### PR DESCRIPTION
## 게임 시작 타이머 메시징 추가

START 타입의 메시지 수신 시
클라이언트로 count 메시지 송신

## 메시지 서버 접속 문제 수정

첫 접속 시 보안에 의해 접속이 안 돼있으면
메시지 서버에도 접속되지 않는 문제가 발생
로그인 후에 정상 접속되도록 수정

## 서버 재시작 시 회원가입 불가 이슈 수정

기존에 남아 있던 jwt 토큰이 원인으로
jwt 토큰을 통해 회원을 검사 후 회원이 존재하지 않는다면
클라이언트의 쿠키를 초기화하여 해결

## 방 인원 제한 문제 수정

메시지를 통해 방 상태 정보가 업데이트 되기 때문에
서버사이드에서 예외처리를 발생하면 문제가 발생
클라이언트에서 처리 요망

## 방장 기능

방을 만든 사용자가 방장이 되며
방 퇴장 시 1에 가까운 사용자를 방장으로 변경
방장 변경 이벤트 메시지 출력

## 게임 시작 기능

게임 시작 메시지 수신 시 5초 후
방의 상태인 start를 true로 변경