### PR TITLE
살해기능 구현 및 스크롤 문제 해결

### DIFF
--- a/client/src/components/chat/Room.jsx
+++ b/client/src/components/chat/Room.jsx
@@ -222,11 +222,12 @@ const Room = ({
   exit,
   visible,
   closeModal,
+  scrollRef,
 }) => {
   return (
     <RoomBlock>
       <ChatBlock>
-        <Chat>
+        <Chat ref={scrollRef}>
           {messageLog &&
             messageLog.map((message, index) => (
               <Message


### PR DESCRIPTION
BaesinZer 일 경우 타겟을 선정하여 죽이면 userInfo의 kill은 죽임 대상의 uesrNo가 저장되며
서버로 KILL메세지를 전송한다.

채팅창에서 스크롤이 올라가 최신 메세지를 볼 수 없었던 것을
스크롤을 항상 아래로 내려 가장 최신의 메세지를 볼 수 있게 오류를 수정하였다.

관련 #18 #42