### PR TITLE
회의 시작 기능 구현

### DIFF
--- a/client/src/components/chat/RoomList.jsx
+++ b/client/src/components/chat/RoomList.jsx
@@ -257,6 +257,7 @@ const RoomList = ({
   makeRoom,
   onChangeRoomName,
   onJoin,
+  onRefresh,
   type,
 }) => {
   if (roomerror) {
@@ -285,6 +286,7 @@ const RoomList = ({
               onChange={changeUsername}
             />
           )}
+          <button onClick={onRefresh}>새로고침</button>
         </NicknameBox>
         <RoomListBox>
           <RoomBox>

--- a/client/src/containers/chat/RoomListContainer.jsx
+++ b/client/src/containers/chat/RoomListContainer.jsx
@@ -49,6 +49,7 @@ const RoomListContainer = ({ history }) => {
     const roomname = e.target.value;
     setRoomName(roomname);
   };
+
   const makeRoom = (e) => {
     e.preventDefault();
     if (roomName == null) {
@@ -60,6 +61,10 @@ const RoomListContainer = ({ history }) => {
     }
 
     dispatch(createRoom(roomName));
+  };
+
+  const onRefresh = () => {
+    dispatch(loadRooms());
   };
 
   // end modal option
@@ -96,6 +101,7 @@ const RoomListContainer = ({ history }) => {
       visible={visible}
       makeRoom={makeRoom}
       onChangeRoomName={onChangeRoomName}
+      onRefresh={onRefresh}
       type={type}
       error={error}
       onJoin={onJoin}

--- a/server/src/main/java/projectw/baesinzer/controller/MessageController.java
+++ b/server/src/main/java/projectw/baesinzer/controller/MessageController.java
@@ -97,9 +97,14 @@ public class MessageController {
                 room.getUsers().put(userInfo.getUserNo(), userInfo);
                 break;
             case VOTE_START:
+                message.setUserInfo(system);
+                message.setMessage("긴급 회의가 시작되었습니다.");
                 for (int i = 1; i <= 6; i++) {
-                    room.getUsers().get(i).setHasVoted(0);
-                    room.getUsers().get(i).setVotedNum(0);
+                    if (room.getUsers().get(i) != null) {
+                        room.getUsers().get(i).setHasVoted(0);
+                        room.getUsers().get(i).setVotedNum(0);
+                        room.getUsers().get(i).setLocationId(0);
+                    }
                 }
                 break;
             case VOTE:
@@ -107,6 +112,7 @@ public class MessageController {
                 UserInfo votedUserInfo = room.getUsers().get(userNo);
                 votedUserInfo.setVotedNum(votedUserInfo.getVotedNum() + 1);
                 room.getUsers().put(userInfo.getUserNo(), userInfo);
+                message.setMessage(userInfo.getUsername() + "이(가) 투표했다.");
                 break;
             case EXIT:
                 UserInfo _userInfo = (UserInfo) headerAccessor.getSessionAttributes().get("user");


### PR DESCRIPTION
# Client

`findDead`: 현 위치에 dead 상태의 유저가 존재하는지 판별 state,
`killLoc`: 범행이 발생한 locationId 저장 state,
`meeting`: 현재 회의가 진행 중인지 판별하는 state

같은 `locationId`에서 dead 상태의 사용자가 발생 시 `killLoc`을 변경, `findDead`를 `true`로 하여 신고 활성화
맵 이동 시 dead 상태의 사용자가 존재하면 `findDead`를 `true`로 하여 신고 활성화
`meeting`이 `true`일 경우 모든 사용자의 메시지 타입을 `ROOM`으로 하여 실시간 채팅 활성화
회의 중 투표 시 서버로 `VOTE` 타입의 메시지를 전송하여 투표 대상 은닉

# Server

메시지 타입 `VOTE_START`를 받으면 회의 시작 메시지와 함께
모든 인원의 투표 정보를 초기화 후 참가자들에게 재전송
`VOTE` 타입의 메시지를 받을 경우 참가자의 정보를 수정하고
대상 은닉 후 메시지를 재전송