### PR TITLE
명령어 관련 이슈 해결

### DIFF
--- a/server/src/main/java/projectw/baesinzer/controller/MessageController.java
+++ b/server/src/main/java/projectw/baesinzer/controller/MessageController.java
@@ -55,7 +55,6 @@ public class MessageController {
                 break;
             case START:
                 message.setUserInfo(system);
-                message.setType(Message.MessageType.ROOM);
                 message.setMessage("5초 뒤 게임이 시작됩니다.");
                 Timer timer = new Timer();
                 TimerTask timerTask = new TimerTask() {


### PR DESCRIPTION
1. 살해 쿨타임 미적용 이슈
원인: 살해 명령에 적용하는 state 중복 적용
해결: 토글 state 선언 및 적용

2. 게임 시작 후 BaesinZer가 아닐 때 살해 명령 관련 메시지 입력할 경우 메시지 출력이 안 되는 이슈
원인: BaesinZer가 아닐 경우의 로직 부재
해결: BaesinZer가 아닐 경우 메시지 기록이 정상적으로 동작하도록 로직 작성

3. 게임 종료 시 메시지가 남아있는 이슈
원인: userInfo의 missionList 변경으로 인한 play 메시지 전송
해결: start state를 모든 인원에게 적용하여 구별

해결: #112