### PR TITLE
미션 10 쿼리 중 명령어 입력 가능 이슈

### DIFF
--- a/client/src/components/chat/missions/Mission10.jsx
+++ b/client/src/components/chat/missions/Mission10.jsx
@@ -69,6 +69,11 @@ const Mission10 = ({ onClose, setMissionDone }) => {
     e.preventDefault();
     setConsoleLog(consoleLog.concat(`> ${command}`));
     const operationArr = command.split(' ');
+    if (querying) {
+      setCommand('');
+      return;
+    }
+
     if (operationArr[0] !== 'query') {
       setConsoleLog(consoleLog.concat(`> ${command}: Unknown command`));
     } else if (operationArr[1] === 'key') {


### PR DESCRIPTION
원인: query 상태의 state 값 코드 누락
해결: query가 true일 경우 아래 로직이 수행되지 않도록 변경

해결: #150