### PR TITLE
게임 재시작 시 투표 진행 이슈 해결

### DIFF
--- a/client/src/containers/chat/RoomContainer.jsx
+++ b/client/src/containers/chat/RoomContainer.jsx
@@ -315,7 +315,6 @@ const RoomContainer = ({ match, history }) => {
         if (!userInfo.dead) {
           stompSend('VOTE_START');
         }
-        stompSend('VOTE_START');
       } else if (!mapInfo && !killInfo && !missionInfo) {
         dispatch(logMessage(userInfo, message));
       }
@@ -607,6 +606,8 @@ const RoomContainer = ({ match, history }) => {
           clear(voteRef);
         }
       }, 1000);
+    } else {
+      clear(voteRef);
     }
   }, [meeting]);
 

--- a/server/src/main/java/projectw/baesinzer/controller/MessageController.java
+++ b/server/src/main/java/projectw/baesinzer/controller/MessageController.java
@@ -159,7 +159,7 @@ public class MessageController {
         message.setUserInfo(system);
 
         if (room.isStart()) {
-            int missions = (room.getCount() - 1) * 4; // 시민의 총 미션 수
+            int missions = (room.getCount() - 1) * 3; // 시민의 총 미션 수
             int alive = room.getCount() - 1;
 
             // 현재 수행된 미션 수 확인
@@ -270,6 +270,7 @@ public class MessageController {
                 message.setType(Message.MessageType.END);
                 message.setUserInfo(system);
                 room.setStart(false);
+                room.getDeadList().clear();
 
                 // 게임 종료 시 게임 내 정보 초기화
                 for (int i = 1; i <= 6; i++) {
@@ -297,6 +298,7 @@ public class MessageController {
     private void gameEnd(Message message, Room room) {
         message.setType(Message.MessageType.END);
         room.setStart(false);
+        room.getDeadList().clear();
 
         // 게임 종료 시 게임 내 정보 초기화
         for (int i = 1; i <= 6; i++) {


### PR DESCRIPTION
1. 투표 시작 두 번 발생 오류
원인: 사용자가 dead 상태일 때 투표 시작을 추가하고 동일한 코드가 있음
해결: 해당 코드 삭제

2. 투표 진행 불가 및 투표 시간 이상
원인: 투표 인터벌이 계속 진행되고 있음
해결: 투표 종료 시 인터벌 초기화

해결: #160
관련: #18