### PR TITLE
배신저의 방해공작 - 암전

### DIFF
--- a/client/src/components/chat/Room.jsx
+++ b/client/src/components/chat/Room.jsx
@@ -335,6 +335,12 @@ const ModalButton = styled.button`
   }
 `;
 
+const TurnOffMessage = styled.div`
+  color: var(--color-red);
+  margin: 1.5rem;
+  text-align: center;
+`;
+
 const Message = React.memo(({ userInfo, message }) => {
   return (
     <UserMessage userNo={userInfo.userNo}>
@@ -492,6 +498,12 @@ const Room = ({
           <BaesinzerText>Baesinzer</BaesinzerText>
         )}
         <AllUsersBox>
+          {turnOff && !userInfo.baesinzer && (
+            <div>
+              <TurnOffMessage> 암전 발생 !</TurnOffMessage>
+              <TurnOffMessage> 시스템 수리중...</TurnOffMessage>
+            </div>
+          )}
           {userInfo && userInfo.baesinzer ? (
             <div>
               {usersArray &&

--- a/client/src/components/chat/Room.jsx
+++ b/client/src/components/chat/Room.jsx
@@ -407,6 +407,9 @@ const Room = ({
   killPossible,
   killTime,
   inputRef,
+  turnOff,
+  disturbancePossible,
+  disturbanceTime,
 }) => {
   return (
     <Block>
@@ -435,10 +438,19 @@ const Room = ({
                     </WorkBoardLeft>
                     <WorkBoardRight>
                       <div>쿨타임</div>
+                      <div></div>
                       <div>이동: {movePossible ? 'Ready' : `${moveTime}s`}</div>
                       {userInfo && userInfo.baesinzer && (
                         <div>
-                          살해: {killPossible ? 'Ready' : `${killTime}s`}
+                          <div>
+                            살해: {killPossible ? 'Ready' : `${killTime}s`}
+                          </div>
+                          <div>
+                            방해:{' '}
+                            {disturbancePossible
+                              ? 'Ready'
+                              : `${disturbanceTime}s`}
+                          </div>
                         </div>
                       )}
                     </WorkBoardRight>
@@ -480,22 +492,47 @@ const Room = ({
           <BaesinzerText>Baesinzer</BaesinzerText>
         )}
         <AllUsersBox>
-          {usersArray &&
-            usersArray.map((user, index) => (
-              <Username
-                key={index}
-                username={user.username}
-                userNo={user.userNo}
-                dead={user.dead}
-              />
-            ))}
-          {deadList &&
-            deadList.map(
-              (deadUser, index) =>
-                deadUser.locationId === userInfo.locationId && (
-                  <DeadUser key={index} username={deadUser.username} />
-                )
-            )}
+          {userInfo && userInfo.baesinzer ? (
+            <div>
+              {usersArray &&
+                usersArray.map((user, index) => (
+                  <Username
+                    key={index}
+                    username={user.username}
+                    userNo={user.userNo}
+                    dead={user.dead}
+                  />
+                ))}
+              {deadList &&
+                deadList.map(
+                  (deadUser, index) =>
+                    deadUser.locationId === userInfo.locationId && (
+                      <DeadUser key={index} username={deadUser.username} />
+                    )
+                )}
+            </div>
+          ) : (
+            <div>
+              {!turnOff &&
+                usersArray &&
+                usersArray.map((user, index) => (
+                  <Username
+                    key={index}
+                    username={user.username}
+                    userNo={user.userNo}
+                    dead={user.dead}
+                  />
+                ))}
+              {!turnOff &&
+                deadList &&
+                deadList.map(
+                  (deadUser, index) =>
+                    deadUser.locationId === userInfo.locationId && (
+                      <DeadUser key={index} username={deadUser.username} />
+                    )
+                )}
+            </div>
+          )}
           {userInfo && userInfo.host && (
             <Start onClick={startHandler}>START</Start>
           )}

--- a/client/src/containers/chat/RoomContainer.jsx
+++ b/client/src/containers/chat/RoomContainer.jsx
@@ -422,6 +422,10 @@ const RoomContainer = ({ match, history }) => {
         // 회의 종료
         setMeeting(false);
         setVotePossible(true);
+      } else if (serverMesg.type === 'TURN_OFF') {
+        // 방해
+        setTurnOff(true);
+        setDisturbancePossible(false);
       } else if (serverMesg.type === 'END') {
         // 게임 종료
         dispatch(initializeMessageLog());
@@ -431,11 +435,7 @@ const RoomContainer = ({ match, history }) => {
         setFlag(false);
         setMissions(false);
         setVotePossible(true);
-      }
-      // 방해
-      else if (serverMesg.type === 'TURN_OFF') {
-        setTurnOff(true);
-        setDisturbancePossible(false);
+        setTurnOff(false);
       }
       dispatch(loadRoomOnMessage(serverMesg.room));
     });
@@ -518,6 +518,8 @@ const RoomContainer = ({ match, history }) => {
       const complexMissionId = complexMissionIds[Math.floor(Math.random() * 2)];
       dispatch(loadMissions({ simpleMissionIds, complexMissionId }));
       setMissions(true);
+    } else {
+      clear(disturbanceRef);
     }
   }, [room && room.start]);
 
@@ -675,13 +677,14 @@ const RoomContainer = ({ match, history }) => {
     }
   }, [meeting]);
 
-  // 방해 공작 쿨 타이머
+  // 방해 공작 및 암전 쿨 타이머
   useEffect(() => {
     if (!disturbancePossible && disturbanceTime > 59 && turnOffTime > 19) {
       let t = 60; // 방해 쿨 타임 60초
       let _t_off = 20; // 암전 시간 20초
 
       disturbanceRef.current = setInterval(() => {
+        // 방해 쿨타임
         if (t > 1) {
           t--;
           setDisturbanceTime(t);
@@ -691,6 +694,8 @@ const RoomContainer = ({ match, history }) => {
           setDisturbancePossible(true);
           setDisturbanceTime(60);
         }
+
+        // 암전 시간
         if (_t_off > 1) {
           _t_off--;
           setTurnOffTime(_t_off);
@@ -698,7 +703,6 @@ const RoomContainer = ({ match, history }) => {
         } else {
           setTurnOff(false);
           setTurnOffTime(20);
-          // dispatch(logMessage(system, '전력 수리가 완료되었습니다. '));
         }
       }, 1000);
     }

--- a/client/src/containers/chat/RoomListContainer.jsx
+++ b/client/src/containers/chat/RoomListContainer.jsx
@@ -30,14 +30,13 @@ const RoomListContainer = ({ history }) => {
 
   // start modal option
   const onClick = () => {
-    //수정-----
-    if (userInfo.username === null || userInfo.username === '') {
+    if (userInfo.username === null || userInfo.username === ' ') {
       setVisible(false);
       setType('닉네임');
       setError('닉네임을 입력하세요.');
-    } else if (userInfo.username.length > 8) {
+    } else if (userInfo.username.length > 5) {
       setType('닉네임');
-      setError('닉네임이 너무 깁니다.');
+      setError('5글자 이내로 작성하세요');
     } else setVisible(!visible);
     setTimeout(function () {
       setError(null);


### PR DESCRIPTION
1. "/방해" 또는 "/disturbance" 명령어 입력 시 방해 토글 출력
2. 방해 명령 토글 활성화 뒤 1번 전력공급 중단 옵션 선택 시 20 초간의 암전 시간 거침
3. stompSend로 서버에 "TURN_OFF" 메세지 전달
4. 서버로부터 TURN_OFF 메세지를 전달 받으면 암전을 발생시키는 TurnOff 변수 true로 활성화,
5. 그와 동시에 방해공작은 60초 동안 작동되지 않기 위해 disturbancePossible을 false로 변경
6. 암전 시간 동안 user들의 맵 트랙킹 정보 메세지가 출력되지 않기 위해 이와 관련된 useEffect부분에 !turnOff조건을 추가
7. 타이머 관련하여 방해 공작은 60초, 암전시간은 20초로 설정.
8. 또한 20초의 암전 시간이 흐른 뒤 userList의 정보를 출력하며 System으로부터 전력 공급 재개의 의미인 메세지를 받음
9. 배신저의 경우 암전 관계 없이 UserList 출력 + 일반 시민의 경우 20초의 암전 시간 동안 UserList 블랙 처리
10. 방해 공작 옵션 안에 암전옵션 존재
11. 배신저와 일반 시민의 암전관련 시스템 메세지에 차이를 둬 출력

구현 #169